### PR TITLE
Wrap sql(x) structs to make it easier to replace to other sql libs

### DIFF
--- a/dbwrapper/dbwrapper.go
+++ b/dbwrapper/dbwrapper.go
@@ -11,3 +11,21 @@ type DB struct {
 type Tx struct {
 	*sqlx.Tx
 }
+
+// Open returns a DB reference for a data source.
+func Open(dataDriver, dataSourceName string) (*DB, error) {
+	db, err := sqlx.Open(dataDriver, dataSourceName)
+	if err != nil {
+		return nil, err
+	}
+	return &DB{db}, nil
+}
+
+// Connect returns a DB reference for a data source.
+func Connect(dataDriver, dataSourceName string) (*DB, error) {
+	db, err := sqlx.Connect(dataDriver, dataSourceName)
+	if err != nil {
+		return nil, err
+	}
+	return &DB{db}, nil
+}

--- a/dbwrapper/dbwrapper.go
+++ b/dbwrapper/dbwrapper.go
@@ -11,12 +11,3 @@ type DB struct {
 type Tx struct {
 	*sqlx.Tx
 }
-
-// // Beginx starts and returns a new transaction
-// func (db *DB) Beginx() (*Tx, error) {
-// 	tx, err := db.DB.Beginx()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return &Tx{tx}, nil
-// }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -7,24 +7,14 @@ import (
 	"net/http"
 	"time"
 
-	"goweb/dbwrapper"
 	"goweb/models"
 	"goweb/transactions"
 
 	"github.com/gorilla/mux"
 )
 
-type DB dbwrapper.DB
-
-// type Tx transactions.Tx
-
-// Beginx starts and returns a new transaction
-func (db *DB) Beginx() (*transactions.Tx, error) {
-	tx, err := db.DB.Beginx()
-	if err != nil {
-		return nil, err
-	}
-	return &transactions.Tx{Tx: tx}, nil
+type DB struct {
+	*transactions.DB
 }
 
 func (db *DB) UserHandler() http.Handler {
@@ -32,7 +22,7 @@ func (db *DB) UserHandler() http.Handler {
 		vars := mux.Vars(r)
 		name := vars["name"]
 
-		tx, err := db.Beginx()
+		tx, err := db.Begin()
 		if err != nil {
 			log.Println(err)
 		}
@@ -62,7 +52,7 @@ func (db *DB) UserList() http.Handler {
 
 func (db *DB) GenDataHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tx, err := db.Beginx()
+		tx, err := db.Begin()
 		if err != nil {
 			log.Println(err)
 		}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -7,14 +7,21 @@ import (
 	"net/http"
 	"time"
 
+	"goweb/dbwrapper"
 	"goweb/models"
 	"goweb/transactions"
 
 	"github.com/gorilla/mux"
 )
 
-type DB struct {
-	*transactions.DB
+type DB dbwrapper.DB
+
+func (db *DB) Begin() (*transactions.Tx, error) {
+	tx, err := db.DB.Beginx()
+	if err != nil {
+		return nil, err
+	}
+	return &transactions.Tx{Tx: tx}, nil
 }
 
 func (db *DB) UserHandler() http.Handler {

--- a/main.go
+++ b/main.go
@@ -10,9 +10,9 @@ import (
 	"os"
 
 	"github.com/gorilla/mux"
-	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 
+	"goweb/dbwrapper"
 	"goweb/handlers"
 )
 
@@ -44,7 +44,7 @@ func main() {
 		postgresHost,
 		os.Getenv("POSTGRES_DB"))
 
-	db, err := sqlx.Connect("postgres", dsn+"?sslmode=disable")
+	db, err := dbwrapper.Connect("postgres", dsn+"?sslmode=disable")
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -59,7 +59,7 @@ func main() {
 	// Create our logger
 	logger := log.New(os.Stdout, "", 0)
 
-	mydb := &handlers.DB{DB: db}
+	mydb := &handlers.DB{DB: db.DB}
 	r := mux.NewRouter()
 
 	// my version of 'HTTP closure'

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	// Create our logger
 	logger := log.New(os.Stdout, "", 0)
 
-	mydb := &handlers.DB{DB: db.DB}
+	hDB := &handlers.DB{DB: db.DB}
 	r := mux.NewRouter()
 
 	// my version of 'HTTP closure'
@@ -70,11 +70,11 @@ func main() {
 	// hanlder with no closure
 	r.HandleFunc("/about", handlers.About)
 
-	r.Handle("/users", mydb.UserList()).Methods("GET", "HEAD")
-	r.Handle("/user/{name}", mydb.UserHandler())
-	r.Handle("/gendata", mydb.GenDataHandler()).Methods("GET")
+	r.Handle("/users", hDB.UserList()).Methods("GET", "HEAD")
+	r.Handle("/user/{name}", hDB.UserHandler())
+	r.Handle("/gendata", hDB.GenDataHandler()).Methods("GET")
 
-	r.Handle("/_user/{name}", handlers.WithMetrics(logger, mydb.UserHandler()))
+	r.Handle("/_user/{name}", handlers.WithMetrics(logger, hDB.UserHandler()))
 
 	http.ListenAndServe(":8080", r)
 }

--- a/transactions/transactions.go
+++ b/transactions/transactions.go
@@ -6,7 +6,16 @@ import (
 	"goweb/models"
 )
 
+type DB dbwrapper.DB
 type Tx dbwrapper.Tx
+
+func (db *DB) Begin() (*Tx, error) {
+	tx, err := db.DB.Beginx()
+	if err != nil {
+		return nil, err
+	}
+	return &Tx{tx}, nil
+}
 
 func (tx *Tx) GenerateData() {
 	tx.MustExec("INSERT INTO person (first_name, last_name, email) VALUES ($1, $2, $3)", "Jason", "Moiron", "jmoiron@jmoiron.net")

--- a/transactions/transactions.go
+++ b/transactions/transactions.go
@@ -21,7 +21,7 @@ func (tx *Tx) GenerateData() {
 	// }
 }
 
-// CreatePerson create a fucking person
+// CreatePerson create a person in the db
 func (tx *Tx) CreatePerson(p *models.Person) error {
 	// Validate the input
 	if p == nil {

--- a/transactions/transactions.go
+++ b/transactions/transactions.go
@@ -6,16 +6,7 @@ import (
 	"goweb/models"
 )
 
-type DB dbwrapper.DB
 type Tx dbwrapper.Tx
-
-func (db *DB) Begin() (*Tx, error) {
-	tx, err := db.DB.Beginx()
-	if err != nil {
-		return nil, err
-	}
-	return &Tx{tx}, nil
-}
 
 func (tx *Tx) GenerateData() {
 	tx.MustExec("INSERT INTO person (first_name, last_name, email) VALUES ($1, $2, $3)", "Jason", "Moiron", "jmoiron@jmoiron.net")


### PR DESCRIPTION
So we can replace `sqlx` with other (like the standard `sql` lib) without changing codes in other modules.
Replacing sql lib is supposed to be done just in `dbwrapper` module.
